### PR TITLE
bug fix

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,6 +1,6 @@
 {% extends template.self %}
 
 {% block javascript %}
-    <script src='/gitbook/gitbook-plugin-new-flowchart/raphael-min.js'></script>
+    <script src='../gitbook/gitbook-plugin-new-flowchart/raphael-min.js'></script>
     {{ super() }}
 {% endblock %}


### PR DESCRIPTION
When gitbook is under a sub-folder, raphael does not load as the path is wrong. This corrects it.